### PR TITLE
Fix parsing of order info by adding default self-trading param to Aeson instance

### DIFF
--- a/src/Coinbase/Exchange/Types/Private.hs
+++ b/src/Coinbase/Exchange/Types/Private.hs
@@ -423,7 +423,7 @@ instance FromJSON Order where
                 <$> m .: "id"
                 <*> m .: "product_id"
                 <*> m .: "status"
-                <*> m .: "stp"
+                <*> m .:? "stp" .!= DecrementAndCancel
                 <*> m .: "settled"
                 <*> m .: "side"
                 <*> m .: "created_at"


### PR DESCRIPTION
This fixes a runtime error on parsing order info received from the server whenever the server doesn't specify this parameter, which is the common case.