### PR TITLE
Fix parsing 'client_oid' in websocket feed

### DIFF
--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -24,7 +24,6 @@ import           Coinbase.Exchange.Types.Core hiding (OrderStatus (..))
 -------------------------------------------------------------------------------
 
 
-
 -------------------------------------------------------------------------------
 -- | Messages we can send to the exchange
 data SendExchangeMessage
@@ -193,7 +192,7 @@ instance FromJSON ExchangeMessage where
                     Just _ -> limit <|> market
             "received" -> do
                 typ  <- m .:  "order_type"
-                mcid <- m .:? "client_oid"
+                mcid <- (m .:? "client_oid") <|> pure Nothing -- parsing never fails here, opaque field if cannot parse UUID
                 case typ of
                     Limit -> ReceivedLimit
                                 <$> m .: "time"

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -192,7 +192,7 @@ instance FromJSON ExchangeMessage where
                     Just _ -> limit <|> market
             "received" -> do
                 typ  <- m .:  "order_type"
-                mcid <- (m .:? "client_oid") <|> pure Nothing -- parsing never fails here, opaque field if cannot parse UUID
+                mcid <- (m .:? "client_oid") .:! Nothing -- Set to Nothing when field is present but UUID parse fails, typically when field is set to empty string
                 case typ of
                     Limit -> ReceivedLimit
                                 <$> m .: "time"

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -192,7 +192,7 @@ instance FromJSON ExchangeMessage where
                     Just _ -> limit <|> market
             "received" -> do
                 typ  <- m .:  "order_type"
-                mcid <- (m .:? "client_oid") .:! Nothing -- Set to Nothing when field is present but UUID parse fails, typically when field is set to empty string
+                mcid <- m .:? "client_oid" .!= Nothing -- Set to Nothing when field is present but UUID parse fails, typically when field is set to empty string
                 case typ of
                     Limit -> ReceivedLimit
                                 <$> m .: "time"


### PR DESCRIPTION
This field is showing up as client_oid:"" but the empty
string could not be parsed as a UUID and was causing the parse to
fail. We are ignoring this field if it cannot be parsed as a UUID now.
It has become "opaque" in that case.