### PR TITLE
Remove unnecessary (.:??) parsing operator

### DIFF
--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -214,8 +214,8 @@ instance FromJSON ExchangeMessage where
                                 <*> (do
                                         -- I can't try to parse "size" or "funds" with (.:?) here, their type is CoinScientific
                                         -- but the fields may be "size":null and that will fail the (m .:? "size") parser.
-                                        ms <- m .:?? "size"
-                                        mf <- m .:?? "funds"
+                                        ms <- m .:? "size"
+                                        mf <- m .:? "funds"
                                         case (ms,mf) of
                                             (Nothing, Nothing) -> mzero
                                             (Just s , Nothing) -> return $ Left  s
@@ -225,17 +225,6 @@ instance FromJSON ExchangeMessage where
             "error" -> error (show m)
 
     parseJSON _ = mzero
-
----------------------------
--- This is based on the code for Aeson's (.:?) operator. Except, we're more
--- lax than (.:?) and also return 'Nothing' when the field is (JSON) null.
-(.:??) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
-obj .:?? key = case H.lookup key obj of
-               Nothing -> pure Nothing
-               Just v  -> if v == Null
-                   then pure Nothing
-                   else obj .:? key
-
 
 -------------------------------------------------------------------------------
 instance ToJSON SendExchangeMessage where


### PR DESCRIPTION
Aeson changed the behavior of (.:?) a few versions back, this is no longer needed.