### PR TITLE
Fix heartbeats

### DIFF
--- a/src/Coinbase/Exchange/Socket.hs
+++ b/src/Coinbase/Exchange/Socket.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Coinbase.Exchange.Socket
-    ( subscribe
+    ( setHeartbeat
+    , subscribe
     , module Coinbase.Exchange.Types.Socket
     ) where
 

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -134,10 +134,10 @@ instance NFData ExchangeMessage
 instance FromJSON ExchangeMessage where
     parseJSON (Object m) = do
         msgtype <- m .: "type"
-        -- TO DO: `HeartbeatReq` and `Subscribe` message types are missing as those are
-        -- never received by the client.
-        case (msgtype :: String) of
-            "hearbeat"-> Heartbeat
+        -- TO DO: `Subscribe` message type is missing as it is never received
+        -- by the client.
+        case (msgtype :: Text) of
+            "heartbeat"-> Heartbeat
                 <$> m .: "time"
                 <*> m .: "product_id"
                 <*> m .: "sequence"
@@ -348,3 +348,11 @@ instance ToJSON ExchangeMessage where
                     Right (ms,f) -> case ms of
                                 Nothing -> ( []            , ["funds" .= f] )
                                 Just s' -> ( ["size" .= s'], ["funds" .= f] )
+
+    toJSON Heartbeat{..} = object
+       [ "type"          .= ("heartbeat" :: Text)
+       , "time"          .= msgTime
+       , "product_id"    .= msgProductId
+       , "sequence"      .= msgSequence
+       , "last_trade_id" .= msgLastTradeId
+       ]

--- a/test/Coinbase/Exchange/Socket/Test.hs
+++ b/test/Coinbase/Exchange/Socket/Test.hs
@@ -58,10 +58,11 @@ parseSocket conf market challenge = subscribe (apiType conf) market $ \conn -> d
 -- a more thorough test would be better.
 reencodeSocket :: ExchangeConf -> [ProductId] -> IO ()
 reencodeSocket conf market = subscribe (apiType conf) market $ \conn -> do
-    sequence_ $ replicate 1000 (decodeEncode conn)
+    sequence_ $ replicate 10 (decodeEncode conn)
 
 decodeEncode :: WS.Connection -> IO ()
 decodeEncode conn = do
+    setHeartbeat True conn
     ds <- WS.receiveData conn
     let res = eitherDecode ds
     case res :: Either String ExchangeMessage of
@@ -80,6 +81,7 @@ decodeEncode conn = do
 
 receiveAndDecode :: WS.Connection -> IO ()
 receiveAndDecode conn = do
+    setHeartbeat True conn
     ds <- WS.receiveData conn
     let res = eitherDecode {- $ trace (show ds) -} ds
     case res :: Either String ExchangeMessage of

--- a/test/Coinbase/Exchange/Socket/Test.hs
+++ b/test/Coinbase/Exchange/Socket/Test.hs
@@ -58,7 +58,7 @@ parseSocket conf market challenge = subscribe (apiType conf) market $ \conn -> d
 -- a more thorough test would be better.
 reencodeSocket :: ExchangeConf -> [ProductId] -> IO ()
 reencodeSocket conf market = subscribe (apiType conf) market $ \conn -> do
-    sequence_ $ replicate 10 (decodeEncode conn)
+    sequence_ $ replicate 1000 (decodeEncode conn)
 
 decodeEncode :: WS.Connection -> IO ()
 decodeEncode conn = do


### PR DESCRIPTION
This patch (1) fixes a runtime error on parsing heartbeats (due to typo), exposes the `setHeartbeat` function, and (3) turns on heartbeats in the tests, while also reducing the number of decode-encode tests on messages received from the server from 1000 to 10.

Note that (3) has a couple of side-effects beyond actually testing the parsing of heartbeats. With heartbeats turned on, the client will always receive at least one message per second from the server (if all is well), so tests on the sandbox server no longer fail due inactivity, as they previously typically did. But this also means that the tests now pass even when the only messages received and passed to the encode-decode test are heartbeats. This is undesirable, but IMO the tests require some major work for a number of reasons; I'm about to open a separate issue describing some of the problems there.