### PR TITLE
Remove ResourceT and move to LTS-15.12

### DIFF
--- a/haskell-coinbase-pro.cabal
+++ b/haskell-coinbase-pro.cabal
@@ -104,6 +104,7 @@ test-suite test-coinbase
                     ,   tasty-hunit
                     ,   QuickCheck
                     ,   quickcheck-instances
+                    ,   generic-random
 
                     ,   uuid
                     ,   bytestring
@@ -117,8 +118,6 @@ test-suite test-coinbase
                     ,   async
                     ,   websockets
                     ,   aeson
-                    ,   aeson-qq
                     ,   unordered-containers
-                    ,   generic-random
 
                     ,   haskell-coinbase-pro

--- a/haskell-coinbase-pro.cabal
+++ b/haskell-coinbase-pro.cabal
@@ -30,6 +30,7 @@ library
 
     build-depends:      base    >= 4 && < 5
                     ,   mtl
+                    ,   monad-control
                     ,   resourcet
                     ,   transformers-base
                     ,   conduit
@@ -44,7 +45,6 @@ library
                     ,   time
                     ,   scientific
                     ,   uuid
-                    ,   uuid-aeson
                     ,   vector
                     ,   hashable
                     ,   deepseq

--- a/src/Coinbase/Exchange/MarketData.hs
+++ b/src/Coinbase/Exchange/MarketData.hs
@@ -24,11 +24,10 @@ module Coinbase.Exchange.MarketData
 
 import           Control.Monad.Except
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Resource
+import           Control.Monad.Catch
 import           Data.List
 import qualified Data.Text                          as T
 import           Data.Time
-import           Data.UUID.Aeson                    ()
 
 #if MIN_VERSION_time(1,5,0)
 import           Data.Time.Format                   (defaultTimeLocale)
@@ -43,34 +42,34 @@ import           Coinbase.Exchange.Types.MarketData
 
 -- Products
 
-getProducts :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getProducts :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
             => m [Product]
 getProducts = coinbaseGet False "/products" voidBody
 
 -- Order Book
 
-getTopOfBook :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getTopOfBook :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
              => ProductId -> m (Book Aggregate)
 getTopOfBook (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/book?level=1") voidBody
 
-getTop50OfBook :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getTop50OfBook :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
                => ProductId -> m (Book Aggregate)
 getTop50OfBook (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/book?level=2") voidBody
 
-getOrderBook :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getOrderBook :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
              => ProductId -> m (Book OrderId)
 getOrderBook (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/book?level=3") voidBody
 
 -- Product Ticker
 
-getProductTicker :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getProductTicker :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
                  => ProductId -> m Tick
 getProductTicker (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/ticker") voidBody
 
 -- Product Trades
 
 -- | Currently Broken: coinbase api doesn't return valid ISO 8601 dates for this route.
-getTrades :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getTrades :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
           => ProductId -> m [Trade]
 getTrades (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/trades") voidBody
 
@@ -80,7 +79,7 @@ type StartTime  = UTCTime
 type EndTime    = UTCTime
 type Scale      = Int
 
-getHistory :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getHistory :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
            => ProductId -> Maybe StartTime -> Maybe EndTime -> Maybe Scale -> m [Candle]
 getHistory (ProductId p) start end scale = coinbaseGet False path voidBody
     where path   = "/products/" ++ T.unpack p ++ "/candles?" ++ params
@@ -96,18 +95,18 @@ getHistory (ProductId p) start end scale = coinbaseGet False path voidBody
 
 -- Product Stats
 
-getStats :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getStats :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
          => ProductId -> m Stats
 getStats (ProductId p) = coinbaseGet False ("/products/" ++ T.unpack p ++ "/stats") voidBody
 
 -- Exchange Currencies
 
-getCurrencies :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getCurrencies :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
               => m [Currency]
 getCurrencies = coinbaseGet False "/currencies" voidBody
 
 -- Exchange Time
 
-getExchangeTime :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+getExchangeTime :: (MonadIO m, MonadThrow m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
                 => m ExchangeTime
 getExchangeTime = coinbaseGet False "/time" voidBody

--- a/src/Coinbase/Exchange/Types/Core.hs
+++ b/src/Coinbase/Exchange/Types/Core.hs
@@ -20,7 +20,6 @@ import           Data.Text           (Text)
 import qualified Data.Text           as T
 import           Data.Time
 import           Data.UUID
-import           Data.UUID.Aeson     ()
 import           Data.Word
 import           GHC.Generics
 import           Text.Read           (readMaybe)

--- a/src/Coinbase/Exchange/Types/MarketData.hs
+++ b/src/Coinbase/Exchange/Types/MarketData.hs
@@ -20,7 +20,6 @@ import           Data.String
 import           Data.Text                    (Text)
 import           Data.Time
 import           Data.Time.Clock.POSIX
-import           Data.UUID.Aeson              ()
 import qualified Data.Vector                  as V
 import           Data.Word
 import           GHC.Generics

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- aeson-1.0.2.1
-- uuid-aeson-0.1.0.0
-resolver: lts-9.5
+resolver: lts-15.12

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: aeson-1.0.2.1@sha256:cf848d5d07a3e6962d7a274d452c772bc1c413a0f9f2d5f112fdde4556a7d7f1,5796
-    pantry-tree:
-      size: 5948
-      sha256: b91857860ef3cefc374e62b64bc10fe94c1932729f69c8c8261d7e8c1d5358e2
-  original:
-    hackage: aeson-1.0.2.1
-- completed:
-    hackage: uuid-aeson-0.1.0.0@sha256:5fe65c563ef474292cf59cda8e36416dd75a60a05fc1fb8be43a0bd2eba1d814,874
-    pantry-tree:
-      size: 327
-      sha256: 206fd0b2fccd183e65496bf936843c944a13bf8ca7a6bf3acb00f66d06fdd1ab
-  original:
-    hackage: uuid-aeson-0.1.0.0
+packages: []
 snapshots:
 - completed:
-    size: 535471
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/9/5.yaml
-    sha256: 452763f820c6cf01f7c917c71dd4e172578d7e53a7763bce863b99f9a8bc843d
-  original: lts-9.5
+    size: 494635
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/12.yaml
+    sha256: a71c4293d8f461f455ff0d9815dfe4ab2f1adacd7e0bbc9a218f46ced8c4929a
+  original: lts-15.12

--- a/test/Coinbase/Exchange/Private/Test.hs
+++ b/test/Coinbase/Exchange/Private/Test.hs
@@ -50,13 +50,13 @@ tests conf = testGroup "Private"
                                             assertEqual "accounts match" usdAccount ac
                                         )
 
-        ,testCase "getUSDAccountLedger" (do as <- run_getAccountList conf
-                                            let usdAccount = findUSDAccount as
-                                            es <- run_getAccountLedger conf (accId usdAccount)
-                                            case es of
-                                                [] -> assertFailure "Received empty list of ledger entries" -- must not be empty to test parser
-                                                _  -> return ()
-                                        )
+        , testCase "getUSDAccountLedger" ( do as <- run_getAccountList conf
+                                              let usdAccount = findUSDAccount as
+                                              es <- run_getAccountLedger conf (accId usdAccount)
+                                              case es of
+                                                  [] -> assertFailure "Received empty list of ledger entries" -- must not be empty to test parser
+                                                  _  -> return ()
+                                         )
 
         , testCase "placeOrder"         (do o   <- creatNewLimitOrder
                                             oid <- run_placeOrder conf o             -- limit order

--- a/test/Coinbase/Exchange/Socket/Test.hs
+++ b/test/Coinbase/Exchange/Socket/Test.hs
@@ -8,13 +8,12 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Monad
 import Data.Aeson
-import Data.Aeson.QQ -- TODO: Replace with Aeson.QQ.Simple after
-                     -- updating to aeson-1.4.2.0 or newer
+import Data.Aeson.QQ.Simple
+
 import Data.ByteString.Lazy (fromStrict)
 import Data.UUID
 
-import Generic.Random.Generic --TODO: The final `.Generic` will go away after
-                              -- updating to newer version
+import Generic.Random
 
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Instances
@@ -761,7 +760,7 @@ decodeInvertsEncode x =
 -- in property tests using QuickCheck
 
 instance Arbitrary Channel where
-  arbitrary = elements allChannels
+  arbitrary = genericArbitraryU
 
 instance Arbitrary Subscription where
   arbitrary = genericArbitraryU
@@ -772,9 +771,6 @@ instance Arbitrary (Status Currency) where
 instance Arbitrary (Status Product) where
   arbitrary = genericArbitraryU
 
--- TODO: The two instances for `Status` can be combined in a single instance for
--- `Status a` with `liftArbitrary`, but it isn't available in the old version
--- of QuickCheck we're using.
 instance Arbitrary Product where
   arbitrary = genericArbitraryU
 
@@ -836,10 +832,3 @@ instance Arbitrary ClientOrderId where
 
 instance Arbitrary Reason where
   arbitrary = genericArbitraryU
-
---------------------------------------------------------------------------------
--- FIXME: This is a hack. Newer versions of the `quickcheck-instances` package
--- provide a proper `Arbitrary` instance for `UUID`. Delete this after updating
--- package dependencies.
-instance Arbitrary UUID where
-  arbitrary = elements [nil]


### PR DESCRIPTION
The API is using ExceptT on top of IO. This is not a good idea as
it makes the error reporting ambiguous. We should fix this.

At the same time, we were using ResourceT and that now depends on
MonadUnliftIO which was failing the build. Our REST API calls do not
return large bodies. So, I simply removed ResourceT. This allowed for
an easier transition to the newer stackage LTS version.

The library now build on the latest stackage LTS-15.12
Testing on cabal still to be done.