### PR TITLE
Replace `FromJSON` instance for `EntryId` to fix failing test

### DIFF
--- a/src/Coinbase/Exchange/Types/Private.hs
+++ b/src/Coinbase/Exchange/Types/Private.hs
@@ -48,7 +48,12 @@ instance FromJSON Account where
 --
 
 newtype EntryId = EntryId { unEntryId :: Word64 }
-    deriving (Eq, Ord, Num, Show, Read, Data, Typeable, Generic, NFData, Hashable, FromJSON, ToJSON)
+    deriving (Eq, Ord, Num, Show, Read, Data, Typeable, Generic, NFData, Hashable, ToJSON)
+
+instance FromJSON EntryId where
+    parseJSON (String t) = pure $ EntryId $ read $ T.unpack t
+    parseJSON (Number n) = pure $ EntryId $ floor n
+    parseJSON _          = mzero
 
 data Entry
     = Entry


### PR DESCRIPTION
This replaces the derived `FromJSON` instance for `EntryId` with a hand-written instance that is exactly parallel to the existing instance for `TradeId`, which is also a newtype over `Word64`. This fixes the failing `getUSDAccountLedger` test; see #18.

I don't know when or why this test started to fail. It seems odd that the instances for `EntryId` and `TradeId` were different. I believe Coinbase's JSON has used strings for everything, including numbers, as long as I've been paying attention.

We can merge this now or wait to see whether there's anything we can do to fix the rest of the tests, whatever you think makes sense.